### PR TITLE
- Fix: `collapse_fields` was only working on the first instance of th…

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
 # Changelog
 
+# UNRELEASED
+
+- Fix: `collapse_fields` was only working on the first instance of the field, not when it was found inside a map etc. later on.
+
 # 0.5 - 2024-02-26
 
 - Fix: oneofs were not being emitted.

--- a/avro/typeRepo.go
+++ b/avro/typeRepo.go
@@ -3,6 +3,7 @@ package avro
 import (
   "fmt"
   "github.com/flipp-oss/protoc-gen-avro/input"
+  "slices"
   "strings"
 )
 
@@ -43,6 +44,11 @@ func (r *TypeRepo) SeenType(t NamedType) {
 
 func (r *TypeRepo) GetType(name string) (Type, error) {
   if r.seenTypes[name] {
+    if r.Types[name] != nil {
+      if slices.Contains(r.CollapseFields, r.Types[name].GetName()) {
+        return r.Types[name].(Record).Fields[0].Type, nil
+      }
+    }
     return Bare(r.MappedNamespace(name[1:])), nil
   }
   t, ok := r.Types[name]

--- a/testdata/collapse_fields/Widget.avsc
+++ b/testdata/collapse_fields/Widget.avsc
@@ -171,7 +171,10 @@
       "name": "string_map",
       "type": {
         "type": "map",
-        "values": "testdata.StringList"
+        "values": {
+          "type": "array",
+          "items": "string"
+        }
       },
       "default": {}
     },


### PR DESCRIPTION
…e field, not when it was found inside a map etc. later on.