### PR TITLE
Fix: Still seeing nested `type: { type: {} }` declarations for maps w…

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,8 @@
 
 # UNRELEASED
 
+- Fix: Still seeing nested `type: { type: {} }` declarations for maps where the values are collapsed records (only for first invocation).
+
 # 0.7.2 - 2024-02-28
 
 - Fix: Accidentally removed map defaults, oops!

--- a/avro/map.go
+++ b/avro/map.go
@@ -30,6 +30,22 @@ func (t Map) ToJSON(types *TypeRepo) (any, error) {
   if ok && mapType[0] == "null"{
     valueJson = mapType[1]
   }
+  valueJsonMap, ok := valueJson.(*orderedmap.OrderedMap)
+  if ok {
+    returnedType, _ := valueJsonMap.Get("type")
+    returnedMap, ok := returnedType.(*orderedmap.OrderedMap)
+    if ok {
+     _, hasType := returnedMap.Get("type")
+     if hasType {
+       // it's adding an extra nesting of type: { type: ... } } - we have to flatten it
+       for _, k := range returnedMap.Keys() {
+         val, _ := returnedMap.Get(k)
+          valueJsonMap.Set(k, val)
+       }
+     }
+    }
+
+  }
   jsonMap := orderedmap.New()
   jsonMap.Set("type", "map")
   jsonMap.Set("values", valueJson)

--- a/testdata/base/Foobar.avsc
+++ b/testdata/base/Foobar.avsc
@@ -115,10 +115,10 @@
       "default": {}
     },
     {
-      "name": "string_lists",
+      "name": "string_list_map",
       "type": {
-        "type": "array",
-        "items": {
+        "type": "map",
+        "values": {
           "type": "record",
           "name": "StringList",
           "namespace": "testdata",
@@ -133,6 +133,14 @@
             }
           ]
         }
+      },
+      "default": {}
+    },
+    {
+      "name": "string_lists",
+      "type": {
+        "type": "array",
+        "items": "testdata.StringList"
       },
       "default": []
     }

--- a/testdata/base/Widget.avsc
+++ b/testdata/base/Widget.avsc
@@ -17,6 +17,77 @@
       "default": 0
     },
     {
+      "name": "string_map",
+      "type": {
+        "type": "map",
+        "values": {
+          "type": "record",
+          "name": "StringList",
+          "namespace": "testdata",
+          "fields": [
+            {
+              "name": "data",
+              "type": {
+                "type": "array",
+                "items": "string"
+              },
+              "default": []
+            }
+          ]
+        }
+      },
+      "default": {}
+    },
+    {
+      "name": "strings",
+      "type": "testdata.StringList",
+      "default": ""
+    },
+    {
+      "name": "a_one_of",
+      "type": [
+        "null",
+        {
+          "type": "record",
+          "name": "AOneOf",
+          "namespace": "testdata",
+          "fields": [
+            {
+              "name": "oneof_types",
+              "type": [
+                {
+                  "type": "record",
+                  "name": "TypeA",
+                  "namespace": "testdata",
+                  "fields": [
+                    {
+                      "name": "foo",
+                      "type": "string",
+                      "default": ""
+                    }
+                  ]
+                },
+                {
+                  "type": "record",
+                  "name": "TypeB",
+                  "namespace": "testdata",
+                  "fields": [
+                    {
+                      "name": "bar",
+                      "type": "string",
+                      "default": ""
+                    }
+                  ]
+                }
+              ],
+              "default": null
+            }
+          ]
+        }
+      ],
+      "default": null
+    },
+    {
       "name": "foobar",
       "type": {
         "type": "record",
@@ -135,86 +206,23 @@
             "default": {}
           },
           {
+            "name": "string_list_map",
+            "type": {
+              "type": "map",
+              "values": "testdata.StringList"
+            },
+            "default": {}
+          },
+          {
             "name": "string_lists",
             "type": {
               "type": "array",
-              "items": {
-                "type": "record",
-                "name": "StringList",
-                "namespace": "testdata",
-                "fields": [
-                  {
-                    "name": "data",
-                    "type": {
-                      "type": "array",
-                      "items": "string"
-                    },
-                    "default": []
-                  }
-                ]
-              }
+              "items": "testdata.StringList"
             },
             "default": []
           }
         ]
       }
-    },
-    {
-      "name": "strings",
-      "type": "testdata.StringList",
-      "default": ""
-    },
-    {
-      "name": "string_map",
-      "type": {
-        "type": "map",
-        "values": "testdata.StringList"
-      },
-      "default": {}
-    },
-    {
-      "name": "a_one_of",
-      "type": [
-        "null",
-        {
-          "type": "record",
-          "name": "AOneOf",
-          "namespace": "testdata",
-          "fields": [
-            {
-              "name": "oneof_types",
-              "type": [
-                {
-                  "type": "record",
-                  "name": "TypeA",
-                  "namespace": "testdata",
-                  "fields": [
-                    {
-                      "name": "foo",
-                      "type": "string",
-                      "default": ""
-                    }
-                  ]
-                },
-                {
-                  "type": "record",
-                  "name": "TypeB",
-                  "namespace": "testdata",
-                  "fields": [
-                    {
-                      "name": "bar",
-                      "type": "string",
-                      "default": ""
-                    }
-                  ]
-                }
-              ],
-              "default": null
-            }
-          ]
-        }
-      ],
-      "default": null
     }
   ]
 }

--- a/testdata/collapse_fields/Foobar.avsc
+++ b/testdata/collapse_fields/Foobar.avsc
@@ -115,13 +115,24 @@
       "default": {}
     },
     {
+      "name": "string_list_map",
+      "type": {
+        "type": "map",
+        "values": {
+          "name": "data",
+          "type": "array",
+          "default": [],
+          "items": "string"
+        }
+      },
+      "default": {}
+    },
+    {
       "name": "string_lists",
       "type": {
         "type": "array",
         "items": {
-          "name": "data",
           "type": "array",
-          "default": [],
           "items": "string"
         }
       },

--- a/testdata/collapse_fields/Widget.avsc
+++ b/testdata/collapse_fields/Widget.avsc
@@ -17,6 +17,71 @@
       "default": 0
     },
     {
+      "name": "string_map",
+      "type": {
+        "type": "map",
+        "values": {
+          "name": "data",
+          "type": "array",
+          "default": [],
+          "items": "string"
+        }
+      },
+      "default": {}
+    },
+    {
+      "name": "strings",
+      "type": {
+        "type": "array",
+        "items": "string"
+      },
+      "default": []
+    },
+    {
+      "name": "a_one_of",
+      "type": [
+        "null",
+        {
+          "type": "record",
+          "name": "AOneOf",
+          "namespace": "testdata",
+          "fields": [
+            {
+              "name": "oneof_types",
+              "type": [
+                {
+                  "type": "record",
+                  "name": "TypeA",
+                  "namespace": "testdata",
+                  "fields": [
+                    {
+                      "name": "foo",
+                      "type": "string",
+                      "default": ""
+                    }
+                  ]
+                },
+                {
+                  "type": "record",
+                  "name": "TypeB",
+                  "namespace": "testdata",
+                  "fields": [
+                    {
+                      "name": "bar",
+                      "type": "string",
+                      "default": ""
+                    }
+                  ]
+                }
+              ],
+              "default": null
+            }
+          ]
+        }
+      ],
+      "default": null
+    },
+    {
       "name": "foobar",
       "type": {
         "type": "record",
@@ -135,13 +200,22 @@
             "default": {}
           },
           {
+            "name": "string_list_map",
+            "type": {
+              "type": "map",
+              "values": {
+                "type": "array",
+                "items": "string"
+              }
+            },
+            "default": {}
+          },
+          {
             "name": "string_lists",
             "type": {
               "type": "array",
               "items": {
-                "name": "data",
                 "type": "array",
-                "default": [],
                 "items": "string"
               }
             },
@@ -149,69 +223,6 @@
           }
         ]
       }
-    },
-    {
-      "name": "strings",
-      "type": {
-        "type": "array",
-        "items": "string"
-      },
-      "default": []
-    },
-    {
-      "name": "string_map",
-      "type": {
-        "type": "map",
-        "values": {
-          "type": "array",
-          "items": "string"
-        }
-      },
-      "default": {}
-    },
-    {
-      "name": "a_one_of",
-      "type": [
-        "null",
-        {
-          "type": "record",
-          "name": "AOneOf",
-          "namespace": "testdata",
-          "fields": [
-            {
-              "name": "oneof_types",
-              "type": [
-                {
-                  "type": "record",
-                  "name": "TypeA",
-                  "namespace": "testdata",
-                  "fields": [
-                    {
-                      "name": "foo",
-                      "type": "string",
-                      "default": ""
-                    }
-                  ]
-                },
-                {
-                  "type": "record",
-                  "name": "TypeB",
-                  "namespace": "testdata",
-                  "fields": [
-                    {
-                      "name": "bar",
-                      "type": "string",
-                      "default": ""
-                    }
-                  ]
-                }
-              ],
-              "default": null
-            }
-          ]
-        }
-      ],
-      "default": null
     }
   ]
 }

--- a/testdata/emit_only/Widget.avsc
+++ b/testdata/emit_only/Widget.avsc
@@ -17,6 +17,77 @@
       "default": 0
     },
     {
+      "name": "string_map",
+      "type": {
+        "type": "map",
+        "values": {
+          "type": "record",
+          "name": "StringList",
+          "namespace": "testdata",
+          "fields": [
+            {
+              "name": "data",
+              "type": {
+                "type": "array",
+                "items": "string"
+              },
+              "default": []
+            }
+          ]
+        }
+      },
+      "default": {}
+    },
+    {
+      "name": "strings",
+      "type": "testdata.StringList",
+      "default": ""
+    },
+    {
+      "name": "a_one_of",
+      "type": [
+        "null",
+        {
+          "type": "record",
+          "name": "AOneOf",
+          "namespace": "testdata",
+          "fields": [
+            {
+              "name": "oneof_types",
+              "type": [
+                {
+                  "type": "record",
+                  "name": "TypeA",
+                  "namespace": "testdata",
+                  "fields": [
+                    {
+                      "name": "foo",
+                      "type": "string",
+                      "default": ""
+                    }
+                  ]
+                },
+                {
+                  "type": "record",
+                  "name": "TypeB",
+                  "namespace": "testdata",
+                  "fields": [
+                    {
+                      "name": "bar",
+                      "type": "string",
+                      "default": ""
+                    }
+                  ]
+                }
+              ],
+              "default": null
+            }
+          ]
+        }
+      ],
+      "default": null
+    },
+    {
       "name": "foobar",
       "type": {
         "type": "record",
@@ -135,86 +206,23 @@
             "default": {}
           },
           {
+            "name": "string_list_map",
+            "type": {
+              "type": "map",
+              "values": "testdata.StringList"
+            },
+            "default": {}
+          },
+          {
             "name": "string_lists",
             "type": {
               "type": "array",
-              "items": {
-                "type": "record",
-                "name": "StringList",
-                "namespace": "testdata",
-                "fields": [
-                  {
-                    "name": "data",
-                    "type": {
-                      "type": "array",
-                      "items": "string"
-                    },
-                    "default": []
-                  }
-                ]
-              }
+              "items": "testdata.StringList"
             },
             "default": []
           }
         ]
       }
-    },
-    {
-      "name": "strings",
-      "type": "testdata.StringList",
-      "default": ""
-    },
-    {
-      "name": "string_map",
-      "type": {
-        "type": "map",
-        "values": "testdata.StringList"
-      },
-      "default": {}
-    },
-    {
-      "name": "a_one_of",
-      "type": [
-        "null",
-        {
-          "type": "record",
-          "name": "AOneOf",
-          "namespace": "testdata",
-          "fields": [
-            {
-              "name": "oneof_types",
-              "type": [
-                {
-                  "type": "record",
-                  "name": "TypeA",
-                  "namespace": "testdata",
-                  "fields": [
-                    {
-                      "name": "foo",
-                      "type": "string",
-                      "default": ""
-                    }
-                  ]
-                },
-                {
-                  "type": "record",
-                  "name": "TypeB",
-                  "namespace": "testdata",
-                  "fields": [
-                    {
-                      "name": "bar",
-                      "type": "string",
-                      "default": ""
-                    }
-                  ]
-                }
-              ],
-              "default": null
-            }
-          ]
-        }
-      ],
-      "default": null
     }
   ]
 }

--- a/testdata/foobar.proto
+++ b/testdata/foobar.proto
@@ -30,5 +30,6 @@ message Foobar {
   map<string, string> a_string_map = 11;
   map<string, Blarp> a_blarp_map = 12;
   map<bool, Yowza> a_yowza_map = 13;
-  repeated StringList string_lists = 14;
+  map<string, StringList> string_list_map = 14;
+  repeated StringList string_lists = 15;
 }

--- a/testdata/namespace_map/Foobar.avsc
+++ b/testdata/namespace_map/Foobar.avsc
@@ -115,10 +115,10 @@
       "default": {}
     },
     {
-      "name": "string_lists",
+      "name": "string_list_map",
       "type": {
-        "type": "array",
-        "items": {
+        "type": "map",
+        "values": {
           "type": "record",
           "name": "StringList",
           "namespace": "mynamespace",
@@ -133,6 +133,14 @@
             }
           ]
         }
+      },
+      "default": {}
+    },
+    {
+      "name": "string_lists",
+      "type": {
+        "type": "array",
+        "items": "mynamespace.StringList"
       },
       "default": []
     }

--- a/testdata/namespace_map/Widget.avsc
+++ b/testdata/namespace_map/Widget.avsc
@@ -17,6 +17,77 @@
       "default": 0
     },
     {
+      "name": "string_map",
+      "type": {
+        "type": "map",
+        "values": {
+          "type": "record",
+          "name": "StringList",
+          "namespace": "mynamespace",
+          "fields": [
+            {
+              "name": "data",
+              "type": {
+                "type": "array",
+                "items": "string"
+              },
+              "default": []
+            }
+          ]
+        }
+      },
+      "default": {}
+    },
+    {
+      "name": "strings",
+      "type": "mynamespace.StringList",
+      "default": ""
+    },
+    {
+      "name": "a_one_of",
+      "type": [
+        "null",
+        {
+          "type": "record",
+          "name": "AOneOf",
+          "namespace": "mynamespace",
+          "fields": [
+            {
+              "name": "oneof_types",
+              "type": [
+                {
+                  "type": "record",
+                  "name": "TypeA",
+                  "namespace": "mynamespace",
+                  "fields": [
+                    {
+                      "name": "foo",
+                      "type": "string",
+                      "default": ""
+                    }
+                  ]
+                },
+                {
+                  "type": "record",
+                  "name": "TypeB",
+                  "namespace": "mynamespace",
+                  "fields": [
+                    {
+                      "name": "bar",
+                      "type": "string",
+                      "default": ""
+                    }
+                  ]
+                }
+              ],
+              "default": null
+            }
+          ]
+        }
+      ],
+      "default": null
+    },
+    {
       "name": "foobar",
       "type": {
         "type": "record",
@@ -135,86 +206,23 @@
             "default": {}
           },
           {
+            "name": "string_list_map",
+            "type": {
+              "type": "map",
+              "values": "mynamespace.StringList"
+            },
+            "default": {}
+          },
+          {
             "name": "string_lists",
             "type": {
               "type": "array",
-              "items": {
-                "type": "record",
-                "name": "StringList",
-                "namespace": "mynamespace",
-                "fields": [
-                  {
-                    "name": "data",
-                    "type": {
-                      "type": "array",
-                      "items": "string"
-                    },
-                    "default": []
-                  }
-                ]
-              }
+              "items": "mynamespace.StringList"
             },
             "default": []
           }
         ]
       }
-    },
-    {
-      "name": "strings",
-      "type": "mynamespace.StringList",
-      "default": ""
-    },
-    {
-      "name": "string_map",
-      "type": {
-        "type": "map",
-        "values": "mynamespace.StringList"
-      },
-      "default": {}
-    },
-    {
-      "name": "a_one_of",
-      "type": [
-        "null",
-        {
-          "type": "record",
-          "name": "AOneOf",
-          "namespace": "mynamespace",
-          "fields": [
-            {
-              "name": "oneof_types",
-              "type": [
-                {
-                  "type": "record",
-                  "name": "TypeA",
-                  "namespace": "mynamespace",
-                  "fields": [
-                    {
-                      "name": "foo",
-                      "type": "string",
-                      "default": ""
-                    }
-                  ]
-                },
-                {
-                  "type": "record",
-                  "name": "TypeB",
-                  "namespace": "mynamespace",
-                  "fields": [
-                    {
-                      "name": "bar",
-                      "type": "string",
-                      "default": ""
-                    }
-                  ]
-                }
-              ],
-              "default": null
-            }
-          ]
-        }
-      ],
-      "default": null
     }
   ]
 }

--- a/testdata/preserve_non_string_maps/Foobar.avsc
+++ b/testdata/preserve_non_string_maps/Foobar.avsc
@@ -131,10 +131,10 @@
       "default": []
     },
     {
-      "name": "string_lists",
+      "name": "string_list_map",
       "type": {
-        "type": "array",
-        "items": {
+        "type": "map",
+        "values": {
           "type": "record",
           "name": "StringList",
           "namespace": "testdata",
@@ -149,6 +149,14 @@
             }
           ]
         }
+      },
+      "default": {}
+    },
+    {
+      "name": "string_lists",
+      "type": {
+        "type": "array",
+        "items": "testdata.StringList"
       },
       "default": []
     }

--- a/testdata/preserve_non_string_maps/Widget.avsc
+++ b/testdata/preserve_non_string_maps/Widget.avsc
@@ -17,6 +17,77 @@
       "default": 0
     },
     {
+      "name": "string_map",
+      "type": {
+        "type": "map",
+        "values": {
+          "type": "record",
+          "name": "StringList",
+          "namespace": "testdata",
+          "fields": [
+            {
+              "name": "data",
+              "type": {
+                "type": "array",
+                "items": "string"
+              },
+              "default": []
+            }
+          ]
+        }
+      },
+      "default": {}
+    },
+    {
+      "name": "strings",
+      "type": "testdata.StringList",
+      "default": ""
+    },
+    {
+      "name": "a_one_of",
+      "type": [
+        "null",
+        {
+          "type": "record",
+          "name": "AOneOf",
+          "namespace": "testdata",
+          "fields": [
+            {
+              "name": "oneof_types",
+              "type": [
+                {
+                  "type": "record",
+                  "name": "TypeA",
+                  "namespace": "testdata",
+                  "fields": [
+                    {
+                      "name": "foo",
+                      "type": "string",
+                      "default": ""
+                    }
+                  ]
+                },
+                {
+                  "type": "record",
+                  "name": "TypeB",
+                  "namespace": "testdata",
+                  "fields": [
+                    {
+                      "name": "bar",
+                      "type": "string",
+                      "default": ""
+                    }
+                  ]
+                }
+              ],
+              "default": null
+            }
+          ]
+        }
+      ],
+      "default": null
+    },
+    {
       "name": "foobar",
       "type": {
         "type": "record",
@@ -151,86 +222,23 @@
             "default": []
           },
           {
+            "name": "string_list_map",
+            "type": {
+              "type": "map",
+              "values": "testdata.StringList"
+            },
+            "default": {}
+          },
+          {
             "name": "string_lists",
             "type": {
               "type": "array",
-              "items": {
-                "type": "record",
-                "name": "StringList",
-                "namespace": "testdata",
-                "fields": [
-                  {
-                    "name": "data",
-                    "type": {
-                      "type": "array",
-                      "items": "string"
-                    },
-                    "default": []
-                  }
-                ]
-              }
+              "items": "testdata.StringList"
             },
             "default": []
           }
         ]
       }
-    },
-    {
-      "name": "strings",
-      "type": "testdata.StringList",
-      "default": ""
-    },
-    {
-      "name": "string_map",
-      "type": {
-        "type": "map",
-        "values": "testdata.StringList"
-      },
-      "default": {}
-    },
-    {
-      "name": "a_one_of",
-      "type": [
-        "null",
-        {
-          "type": "record",
-          "name": "AOneOf",
-          "namespace": "testdata",
-          "fields": [
-            {
-              "name": "oneof_types",
-              "type": [
-                {
-                  "type": "record",
-                  "name": "TypeA",
-                  "namespace": "testdata",
-                  "fields": [
-                    {
-                      "name": "foo",
-                      "type": "string",
-                      "default": ""
-                    }
-                  ]
-                },
-                {
-                  "type": "record",
-                  "name": "TypeB",
-                  "namespace": "testdata",
-                  "fields": [
-                    {
-                      "name": "bar",
-                      "type": "string",
-                      "default": ""
-                    }
-                  ]
-                }
-              ],
-              "default": null
-            }
-          ]
-        }
-      ],
-      "default": null
     }
   ]
 }

--- a/testdata/widget.proto
+++ b/testdata/widget.proto
@@ -23,8 +23,8 @@ message AOneOf {
 message Widget {
   optional google.protobuf.Timestamp from_date = 1;
   google.protobuf.Timestamp to_date = 2;
-  Foobar foobar = 3;
-  StringList strings = 4;
-  map<string, StringList> string_map = 5;
+  map<string, StringList> string_map = 4;
+  StringList strings = 5;
   optional AOneOf a_one_of = 6;
+  Foobar foobar = 7;
 }


### PR DESCRIPTION
…here the values are collapsed records (only for first invocation).